### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/prueba/zara/config/SecurityConfig.java
+++ b/src/main/java/com/prueba/zara/config/SecurityConfig.java
@@ -12,7 +12,13 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        )
+                )
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers(
                                 "/v3/api-docs/**",


### PR DESCRIPTION
Potential fix for [https://github.com/david92f/Zara/security/code-scanning/1](https://github.com/david92f/Zara/security/code-scanning/1)

To resolve the issue, CSRF protection should be enabled for the application. This can be achieved by removing the `http.csrf(AbstractHttpConfigurer::disable)` line from the configuration. If certain endpoints (e.g., `/v3/api-docs/**`, `/swagger-ui/**`) genuinely do not require CSRF protection, they can be explicitly exempted using Spring's CSRF configuration methods. The fix ensures that the application will enforce CSRF protection for browser-based clients, mitigating the potential vulnerability.

Steps to implement the fix:
1. Remove the `http.csrf(AbstractHttpConfigurer::disable)` line.
2. Optionally specify exemptions for endpoints that do not require CSRF protection using Spring's `csrf().ignoringRequestMatchers()` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
